### PR TITLE
feat: add keyboard shortcuts for common actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Built with TypeScript and styled with UnoCSS.
 
 - 🎨 Customizable appearance (font size, font family, themes)
 - ⌨️ Built-in commands (help, clear, font adjustment)
+- ⚡ Keyboard shortcuts for common actions:
+  - Ctrl/Cmd + L: Clear console
+  - Ctrl/Cmd + K: Clear input field
+  - Escape: Blur/unfocus input field
 - 🔧 Easy command creation and management
 - 🌐 Global window access for debugging
 - 📦 Multiple build formats (ESM, CJS, UMD, IIFE)


### PR DESCRIPTION
This contribution adds essential keyboard shortcuts to the s-console library, improving user experience and bringing it closer to standard console behavior found in modern browser developer tools.

Added Features
Clear Console (Ctrl/Cmd + L)

Quickly clears the entire console output
Matches the behavior of browser DevTools
Implemented through the existing [clear()]method


Instantly clears the input field without executing any command
Useful when you want to start over typing a command
Similar to terminal emulator behavior
Blur Input (Escape Key)

Allows users to unfocus from the input field
Helpful when you want to interact with other parts of the page
Improves accessibility and keyboard navigation